### PR TITLE
Add command testing buttons

### DIFF
--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -33,9 +33,10 @@ public:
     Q_PROPERTY(int              vehicleFrequency    MEMBER _vehicleFrequency        NOTIFY vehicleFrequencyChanged)
     Q_PROPERTY(int              missedPulseCount    MEMBER _missedPulseCount        NOTIFY missedPulseCountChanged)
 
-    Q_INVOKABLE void start          (void);
+    Q_INVOKABLE void startAndTakeoff(void);
     Q_INVOKABLE void cancelAndReturn(void);
     Q_INVOKABLE void sendTag        (void);
+    Q_INVOKABLE void startDetection (void);
 
     // Overrides from QGCCorePlugin
     QVariantList&       settingsPages           (void) final;
@@ -100,7 +101,6 @@ private:
     void _handleSimulatedStopDetection  (const mavlink_debug_float_array_t& debug_float_array);
     QString _vhfCommandIdToText         (uint32_t vhfCommandId);
     void _sendSimulatedVHFCommandAck    (uint32_t vhfCommandId);
-    void _startDetection                (void);
     void _startFlight                   (void);
 
     QVariantList            _settingsPages;
@@ -118,6 +118,7 @@ private:
     int                     _firstSlice;
     int                     _nextSlice;
     int                     _cSlice;
+    bool                    _startAndTakeoff = false;
 
     qreal                   _beepStrength;
     qreal                   _temp;

--- a/custom/src/CustomSettings.qml
+++ b/custom/src/CustomSettings.qml
@@ -24,27 +24,50 @@ Rectangle {
     anchors.fill:       parent
     anchors.margins:    ScreenTools.defaultFontPixelWidth
 
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
     QGCFlickable {
         clip:               true
         anchors.fill:       parent
-        contentHeight:      grid.height
-        contentWidth:       grid.width
+        contentHeight:      column.height
+        contentWidth:       column.width
 
-        FactTextFieldGrid {
-            id: grid
+        Column {
+            id:         column
+            spacing:    ScreenTools.defaultFontPixelHeight
 
-            factList: [
-                QGroundControl.corePlugin.customSettings.altitude,
-                QGroundControl.corePlugin.customSettings.divisions,
-                QGroundControl.corePlugin.customSettings.tagId,
-                QGroundControl.corePlugin.customSettings.frequency,
-                QGroundControl.corePlugin.customSettings.frequencyDelta,
-                QGroundControl.corePlugin.customSettings.pulseDuration,
-                QGroundControl.corePlugin.customSettings.intraPulse1,
-                QGroundControl.corePlugin.customSettings.intraPulse2,
-                QGroundControl.corePlugin.customSettings.intraPulseUncertainty,
-                QGroundControl.corePlugin.customSettings.intraPulseJitter
-            ]
+            FactTextFieldGrid {
+                id: grid
+
+                factList: [
+                    QGroundControl.corePlugin.customSettings.altitude,
+                    QGroundControl.corePlugin.customSettings.divisions,
+                    QGroundControl.corePlugin.customSettings.tagId,
+                    QGroundControl.corePlugin.customSettings.frequency,
+                    QGroundControl.corePlugin.customSettings.frequencyDelta,
+                    QGroundControl.corePlugin.customSettings.pulseDuration,
+                    QGroundControl.corePlugin.customSettings.intraPulse1,
+                    QGroundControl.corePlugin.customSettings.intraPulse2,
+                    QGroundControl.corePlugin.customSettings.intraPulseUncertainty,
+                    QGroundControl.corePlugin.customSettings.intraPulseJitter
+                ]
+            }
+
+            Row {
+                spacing: ScreenTools.defaultFontPixelWidth * 5
+
+                QGCButton {
+                    text:       "Send Tag"
+                    enabled:    _activeVehicle
+                    onClicked:  QGroundControl.corePlugin.sendTag()
+                }
+
+                QGCButton {
+                    text:       "Start Detection"
+                    enabled:    _activeVehicle
+                    onClicked:  QGroundControl.corePlugin.startDetection()
+                }
+            }
         }
     }
 }

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -514,7 +514,7 @@ Item {
             _activeVehicle.guidedModeLand()
             break
         case actionTakeoff:
-            QGroundControl.corePlugin.start()
+            QGroundControl.corePlugin.startAndTakeoff()
             break
         case actionResumeMission:
         case actionResumeMissionUploadFail:


### PR DESCRIPTION
Buttons to test Send Tag and Start Detection commands added to App Settings/Tags page. NOTE: IF USING THESE BUTTONS ON A REAL VEHICLE IT IS RECOMMENDED TO ALWAYS REMOVE PROPS TO BE SAFE. The vehicle should not takeoff. But it's all software right. So better safe than sorry.

![Screen Shot 2022-09-26 at 2 08 32 PM](https://user-images.githubusercontent.com/5876851/192381239-098df93b-aafc-4ee4-abf5-6c62d5b68f75.png)
