### PR TITLE
Add pulse logging

### DIFF
--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -12,6 +12,7 @@ using namespace uavrt_interfaces;
 #include <QGeoCoordinate>
 #include <QTimer>
 #include <QLoggingCategory>
+#include <QFile>
 
 class CustomSettings;
 
@@ -103,6 +104,8 @@ private:
     void _handleSimulatedStopDetection  (const mavlink_debug_float_array_t& debug_float_array);
     QString _vhfCommandIdToText         (CommandID vhfCommandId);
     void _sendSimulatedVHFCommandAck    (CommandID vhfCommandId);
+    void _logPulseToFile                (const mavlink_debug_float_array_t& debug_float_array);
+    void _logRotateStartStopToFile      (bool start);
 
     QVariantList            _settingsPages;
     QVariantList            _instrumentPages;
@@ -134,6 +137,7 @@ private:
     int                     _lastPulseSendIndex;
     int                     _missedPulseCount;
     QmlObjectListModel      _customMapItems;
+    QFile                   _pulseLogFile;
 
     // Simulator values
     uint32_t    _simulatorTagId                 = 0;


### PR DESCRIPTION
* Pulse logs will be in the `Documents/Tag Tracker Daily/Logs` folder
* File names look like this `Pulse-2022-10-13-10-39-54-344.csv`. With the date/time to make them unique
* There are three record types in the csv. The first field in each row is the record type:
  * 1 - Pulse
    * Example: `1,6190516000,0,7.23439,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,`
    * Field position 1 - Record type 1
    * Field position 2 - DEBUG_FLOAT_ARRAY.time_usec
    * Field positions 3 thru 28 - DEBUG_FLOAT_ARRAY.data[0-25]
  * 2 - Start Rotate
    * Example: `2,47.3978,8.54561,498.072`
    * Field position 1 - Record type 2
    * Field position 2 - Latitude for rotation center
    * Field position 3 - Longitude for rotation center
    * Field position 4 - AMSL altitude for rotation center
  * 3 - Stop Rotate
    * Example: `3,47.3978,8.54561,498.188`
    * Field position 1 - Record type 3
    * Rest are same as start rotate
