### PR TITLE
Strip chart pulse display

### DIFF
--- a/custom/custom.qrc
+++ b/custom/custom.qrc
@@ -6,6 +6,7 @@
         <file alias="QGroundControl/FlightDisplay/CustomGuidedActionStartDetection.qml">src/CustomGuidedActionStartDetection.qml</file>
         <file alias="QGroundControl/FlightDisplay/CustomGuidedActionStopDetection.qml">src/CustomGuidedActionStopDetection.qml</file>
         <file alias="QGroundControl/FlightDisplay/CustomGuidedActionStartRotation.qml">src/CustomGuidedActionStartRotation.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlyViewCustomLayer.qml</file>
     </qresource>
     <qresource prefix="/res">
     </qresource>

--- a/custom/qgroundcontrol.exclusion
+++ b/custom/qgroundcontrol.exclusion
@@ -1,3 +1,3 @@
         <file alias="QGroundControl/FlightDisplay/FlyViewToolStripActionList.qml">src/FlightDisplay/FlyViewToolStripActionList.qml</file>
-        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">../src/FlightDisplay/FlyViewCustomLayer.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlightDisplay/FlyViewCustomLayer.qml</file>
 

--- a/custom/qgroundcontrol.exclusion
+++ b/custom/qgroundcontrol.exclusion
@@ -1,1 +1,3 @@
         <file alias="QGroundControl/FlightDisplay/FlyViewToolStripActionList.qml">src/FlightDisplay/FlyViewToolStripActionList.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">../src/FlightDisplay/FlyViewCustomLayer.qml</file>
+

--- a/custom/qgroundcontrol.qrc
+++ b/custom/qgroundcontrol.qrc
@@ -204,7 +204,6 @@
 		<file alias="QGroundControl/FlightDisplay/FlightDisplayViewWidgets.qml">../src/FlightDisplay/FlightDisplayViewWidgets.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewAirspaceIndicator.qml">../src/FlightDisplay/FlyViewAirspaceIndicator.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyView.qml">../src/FlightDisplay/FlyView.qml</file>
-		<file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">../src/FlightDisplay/FlyViewCustomLayer.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewInstrumentPanel.qml">../src/FlightDisplay/FlyViewInstrumentPanel.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewMap.qml">../src/FlightDisplay/FlyViewMap.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewMissionCompleteDialog.qml">../src/FlightDisplay/FlyViewMissionCompleteDialog.qml</file>
@@ -348,6 +347,7 @@
 		<file alias="General.MetaData.json.xz">../src/comm/MockLink.General.MetaData.json.xz</file>
 		<file alias="Parameter.MetaData.json.xz">../src/comm/MockLink.Parameter.MetaData.json.xz</file>
 		<file alias="Parameter.MetaData.json">../src/comm/MockLink.Parameter.MetaData.json</file>
+		<file alias="Arduplane.params.ftp.bin">../src/comm/Mocklink.Arduplane.params.ftp.bin</file>
 	</qresource>
 	<qresource prefix="/qml">
 		<file alias="QGroundControl/Controls/MockLinkOptionsDlg.qml">../src/comm/MockLinkOptionsDlg.qml</file>

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -168,7 +168,7 @@ void CustomPlugin::_logPulseToFile(const mavlink_debug_float_array_t& debug_floa
     }
 
     _pulseLogFile.write(QString("1,%1,").arg(debug_float_array.time_usec).toUtf8());
-    for (int i=0; i<25; i++) {
+    for (int i=0; i <= static_cast<int>(PulseIndex::PulseIndexLast); i++) {
         _pulseLogFile.write(QString("%1,").arg(static_cast<double>(debug_float_array.data[i]), 0, 'f', 6).toUtf8());
     }
     _pulseLogFile.write("\n");

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -122,18 +122,23 @@ void CustomPlugin::_handleVHFCommandAck(const mavlink_debug_float_array_t& debug
 
 void CustomPlugin::_handleVHFPulse(const mavlink_debug_float_array_t& debug_float_array)
 {
-    double pulseStrength = static_cast<double>(debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexStrength)]);
+    double pulseStrength = static_cast<double>(debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexStrengthLEGACY)]);
 
     _logPulseToFile(debug_float_array);
 
     if (pulseStrength < 0 || pulseStrength > 100) {
         qCDebug(CustomPluginLog) << "PULSE outside range";
     }
-    qCDebug(CustomPluginLog) << "PULSE strength" << pulseStrength;
     pulseStrength = qMax(0.0, qMin(100.0, pulseStrength));
 
     _beepStrength = pulseStrength;
     emit beepStrengthChanged(_beepStrength);
+
+    _pulseTimeSeconds   = debug_float_array.time_usec / 1000000.0;
+    _pulseSNR           = debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexSNR)];
+    _pulseConfirmed     = debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexConfirmedStatus)];
+    qCDebug(CustomPluginLog) << "PULSE time:snr" << _pulseTimeSeconds << _pulseSNR;
+    emit pulseReceived();
 
     _rgPulseValues.append(_beepStrength);
     if (_beepStrength == 0) {
@@ -164,7 +169,7 @@ void CustomPlugin::_logPulseToFile(const mavlink_debug_float_array_t& debug_floa
 
     _pulseLogFile.write(QString("1,%1,").arg(debug_float_array.time_usec).toUtf8());
     for (int i=0; i<25; i++) {
-        _pulseLogFile.write(QString("%1,").arg(debug_float_array.data[i]).toUtf8());
+        _pulseLogFile.write(QString("%1,").arg(static_cast<double>(debug_float_array.data[i]), 0, 'f', 6).toUtf8());
     }
     _pulseLogFile.write("\n");
 }
@@ -183,10 +188,10 @@ void CustomPlugin::_logRotateStartStopToFile(bool start)
 
     QGeoCoordinate coord = vehicle->coordinate();
     _pulseLogFile.write(QString("%1,%2,%3,%4\n").arg(start ? 2 : 3)
-                        .arg(coord.latitude())
-                        .arg(coord.longitude())
-                        .arg(vehicle->altitudeAMSL()->rawValue().toDouble())
-                        .toLocal8Bit().data());
+                        .arg(coord.latitude(), 0, 'f', 6)
+                        .arg(coord.longitude(), 0, 'f', 6)
+                        .arg(vehicle->altitudeAMSL()->rawValue().toDouble(), 0, 'f', 6)
+                        .toUtf8());
 }
 
 #if 0
@@ -689,7 +694,7 @@ void CustomPlugin::_simulatePulse(void)
             mavlink_debug_float_array_t debug_float_array;
 
             debug_float_array.array_id = static_cast<uint16_t>(CommandID::CommandIDPulse);
-            debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexStrength)] = pulse;
+            debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexStrengthLEGACY)] = pulse;
             mavlink_msg_debug_float_array_encode(static_cast<uint8_t>(vehicle->id()), MAV_COMP_ID_AUTOPILOT1, &msg, &debug_float_array);
 
             mavlinkMessage(vehicle, sharedLink.get(), msg);

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -26,8 +26,11 @@ public:
     CustomPlugin(QGCApplication* app, QGCToolbox* toolbox);
     ~CustomPlugin();
 
-    Q_PROPERTY(CustomSettings*  customSettings         MEMBER _customSettings             CONSTANT)
+    Q_PROPERTY(CustomSettings*  customSettings      MEMBER _customSettings          CONSTANT)
     Q_PROPERTY(qreal            beepStrength        MEMBER _beepStrength            NOTIFY beepStrengthChanged)
+    Q_PROPERTY(double           pulseTimeSeconds    MEMBER _pulseTimeSeconds        NOTIFY pulseReceived)
+    Q_PROPERTY(double           pulseSNR            MEMBER _pulseSNR                NOTIFY pulseReceived)
+    Q_PROPERTY(bool             pulseConfirmed      MEMBER _pulseConfirmed          NOTIFY pulseReceived)
     Q_PROPERTY(qreal            temp                MEMBER _temp                    NOTIFY tempChanged)
     Q_PROPERTY(int              bpm                 MEMBER _bpm                     NOTIFY bpmChanged)
     Q_PROPERTY(QList<QList<double>> angleRatios         MEMBER _rgAngleRatios           NOTIFY angleRatiosChanged)
@@ -61,6 +64,7 @@ signals:
     void vehicleFrequencyChanged    (int vehicleFrequency);
     void missedPulseCountChanged    (int missedPulseCount);
     void detectionStatusChanged     (int detectionStatus);
+    void pulseReceived              (void);
 
 private slots:
     void _vehicleStateRawValueChanged   (QVariant rawValue);
@@ -138,6 +142,10 @@ private:
     int                     _missedPulseCount;
     QmlObjectListModel      _customMapItems;
     QFile                   _pulseLogFile;
+
+    double                  _pulseTimeSeconds;
+    double                  _pulseSNR;
+    bool                    _pulseConfirmed;
 
     // Simulator values
     uint32_t    _simulatorTagId                 = 0;

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick                  2.12
+import QtQuick.Controls         2.4
+import QtQuick.Dialogs          1.3
+import QtQuick.Layouts          1.12
+import QtCharts                 2.15
+
+import QtLocation               5.3
+import QtPositioning            5.3
+import QtQuick.Window           2.2
+import QtQml.Models             2.1
+
+import QGroundControl               1.0
+import QGroundControl.Airspace      1.0
+import QGroundControl.Airmap        1.0
+import QGroundControl.Controllers   1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FlightDisplay 1.0
+import QGroundControl.FlightMap     1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+// To implement a custom overlay copy this code to your own control in your custom code source. Then override the
+// FlyViewCustomLayer.qml resource with your own qml. See the custom example and documentation for details.
+Item {
+    id: _root
+
+    property var parentToolInsets               // These insets tell you what screen real estate is available for positioning the controls in your overlay
+    property var totalToolInsets:   _toolInsets // These are the insets for your custom overlay additions
+    property var mapControl
+
+    property real   _toolsMargin:   ScreenTools.defaultFontPixelWidth * 0.75
+    property var    _corePlugin:    QGroundControl.corePlugin
+
+    QGCToolInsets {
+        id:                         _toolInsets
+        leftEdgeCenterInset:    0
+        leftEdgeTopInset:           0
+        leftEdgeBottomInset:        0
+        rightEdgeCenterInset:   0
+        rightEdgeTopInset:          0
+        rightEdgeBottomInset:       0
+        topEdgeCenterInset:       0
+        topEdgeLeftInset:           0
+        topEdgeRightInset:          0
+        bottomEdgeCenterInset:    0
+        bottomEdgeLeftInset:        0
+        bottomEdgeRightInset:       0
+    }
+
+    Rectangle {
+        width:                  parentToolInsets.rightEdgeTopInset
+        anchors.topMargin:      parentToolInsets.topEdgeRightInset
+        anchors.bottom:         parent.bottom
+        anchors.top:            parent.top
+        anchors.right:          parent.right
+        color:                  "white"
+
+        property real _margins: ScreenTools.defaultFontPixelWidth / 2
+
+        ChartView {
+            id:                 chart
+            anchors.fill:       parent
+            antialiasing:       true
+            margins.top:            0
+            margins.bottom:            0
+            margins.left:            0
+            margins.right:            0
+            legend.visible: false
+
+            ValueAxis {
+                id:             axisX
+                min:            0
+                max:            100
+                tickCount:      5
+                labelsVisible:  false
+            }
+
+            ValueAxis {
+                id:         axisY
+                min:        0
+                max:        12
+                tickCount:  12
+                reverse:    true
+            }
+
+            ScatterSeries {
+                id: pulseSeries
+                axisX: axisX
+                axisY: axisY
+            }
+
+            Timer {
+                interval: 100
+                repeat: true
+                running: true
+                onTriggered: {
+                    axisY.min = axisY.min + 0.1
+                    axisY.max = axisY.max + 0.1
+                }
+            }
+
+            Connections {
+                target: _corePlugin
+
+                property bool firstPulse:       true
+                property real timeAdjustment:   0
+
+                function onPulseReceived() {
+                    if (firstPulse) {
+                        firstPulse = false
+                        timeAdjustment = _corePlugin.pulseTimeSeconds + axisY.min
+                    }
+                    console.log("pulse received", _corePlugin.pulseTimeSeconds, timeAdjustment)
+                    pulseSeries.append(_corePlugin.pulseSNR, _corePlugin.pulseTimeSeconds - timeAdjustment);
+                }
+            }
+        }
+
+    }
+}

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -54,12 +54,12 @@ Item {
         leftEdgeTopInset:       toolStrip.leftInset
         leftEdgeCenterInset:    toolStrip.leftInset
         leftEdgeBottomInset:    parentToolInsets.leftEdgeBottomInset
-        rightEdgeTopInset:      parentToolInsets.rightEdgeTopInset
+        rightEdgeTopInset:      _root.width - instrumentPanel.x
         rightEdgeCenterInset:   parentToolInsets.rightEdgeCenterInset
         rightEdgeBottomInset:   parentToolInsets.rightEdgeBottomInset
         topEdgeLeftInset:       parentToolInsets.topEdgeLeftInset
         topEdgeCenterInset:     parentToolInsets.topEdgeCenterInset
-        topEdgeRightInset:      parentToolInsets.topEdgeRightInset
+        topEdgeRightInset:      instrumentPanel.y + instrumentPanel.height
         bottomEdgeLeftInset:    parentToolInsets.bottomEdgeLeftInset
         bottomEdgeCenterInset:  mapScale.centerInset
         bottomEdgeRightInset:   0


### PR DESCRIPTION
Still needs more work. But basics are working:
* Chart slides up as time moves on
* Shows 12 seconds of data continuous data
* Pulse SNR goes from 0-100 left to right.

Remaining work:
* Remove pulse bar thing from toolbar
* Show different blips for confirmed status
* Change compass rose display to use pulse snr values instead of strength and support unbounded snr values. Current max is 100.

![Screen Shot 2022-10-27 at 1 58 01 PM](https://user-images.githubusercontent.com/5876851/198396908-14c705fa-eb07-4bc3-b9a1-5e808d8a0cd2.png)
