### PR TITLE
Workaround DEBUG_FLOAT streaming problem

### DIFF
--- a/custom/custom.pri
+++ b/custom/custom.pri
@@ -7,6 +7,10 @@ CUSTOM_QGC_VER_MAJOR = 0
 CUSTOM_QGC_VER_MINOR = 0
 CUSTOM_QGC_VER_FIRST_BUILD = 0
 
+linux {
+    QMAKE_CXXFLAGS_WARN_ON += -Wno-strict-aliasing
+}
+
 # Build number is automatic
 # Uses the current branch. This way it works on any branch including build-server's PR branches
 CUSTOM_QGC_VER_BUILD = $$system(git --git-dir ../.git rev-list $$GIT_BRANCH --first-parent --count)

--- a/custom/custom.qrc
+++ b/custom/custom.qrc
@@ -6,6 +6,8 @@
         <file alias="QGroundControl/FlightDisplay/CustomGuidedActionStartDetection.qml">src/CustomGuidedActionStartDetection.qml</file>
         <file alias="QGroundControl/FlightDisplay/CustomGuidedActionStopDetection.qml">src/CustomGuidedActionStopDetection.qml</file>
         <file alias="QGroundControl/FlightDisplay/CustomGuidedActionStartRotation.qml">src/CustomGuidedActionStartRotation.qml</file>
+        <file alias="QGroundControl/FlightDisplay/CustomGuidedActionAirspyHF.qml">src/CustomGuidedActionAirspyHF.qml</file>
+        <file alias="QGroundControl/FlightDisplay/CustomGuidedActionAirspyMini.qml">src/CustomGuidedActionAirspyMini.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlyViewCustomLayer.qml</file>
     </qresource>
     <qresource prefix="/res">

--- a/custom/src/CustomFlyViewToolStripActionList.qml
+++ b/custom/src/CustomFlyViewToolStripActionList.qml
@@ -24,6 +24,8 @@ ToolStripActionList {
         GuidedActionRTL { },
         CustomGuidedActionStartDetection { },
         CustomGuidedActionStopDetection { },
-        CustomGuidedActionStartRotation { }
+        CustomGuidedActionStartRotation { },
+        CustomGuidedActionAirspyHF { },
+        CustomGuidedActionAirspyMini { }
     ]
 }

--- a/custom/src/CustomGuidedActionAirspyHF.qml
+++ b/custom/src/CustomGuidedActionAirspyHF.qml
@@ -1,0 +1,19 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QGroundControl               1.0
+import QGroundControl.FlightDisplay 1.0
+
+GuidedToolStripAction {
+    text:       _guidedController.airspyHFTitle
+    iconSource: "/res/action.svg"
+    visible:    true
+    enabled:    QGroundControl.multiVehicleManager.activeVehicle
+    actionID:   _guidedController.actionAirspyHF
+}

--- a/custom/src/CustomGuidedActionAirspyMini.qml
+++ b/custom/src/CustomGuidedActionAirspyMini.qml
@@ -1,0 +1,19 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QGroundControl               1.0
+import QGroundControl.FlightDisplay 1.0
+
+GuidedToolStripAction {
+    text:       _guidedController.airspyMiniTitle
+    iconSource: "/res/action.svg"
+    visible:    true
+    enabled:    QGroundControl.multiVehicleManager.activeVehicle
+    actionID:   _guidedController.actionAirspyMini
+}

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -58,10 +58,11 @@ void CustomPlugin::setToolbox(QGCToolbox* toolbox)
 
 void CustomPlugin::_activeVehicleChanged(Vehicle* activeVehicle)
 {
-    // PX4 firmware streams DEBUG_FLOAT_ARRAY messages for some reason. This in turns screws up our usage of the messages for comms.
-    // So we turn off streaming for that once we see the vehicle connection.
+    // PX4 firmware streams DEBUG_FLOAT_ARRAY messages for some reason. This seems to be the only reliable way to get the message to
+    // flow through the Skynode UDP connection out a SiK radio. We need to up the rate so we don't lose messages.
+    // When connected over non-SiK radio this causes duplicates to be sent. So we need to remove those later.
     disconnect(_toolbox->multiVehicleManager(), &MultiVehicleManager::activeVehicleChanged, this, &CustomPlugin::_activeVehicleChanged);
-    activeVehicle->sendCommand(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_SET_MESSAGE_INTERVAL, true /* showError */, MAVLINK_MSG_ID_DEBUG_FLOAT_ARRAY, -1 /* disable */, 0 /* flight stack */);
+    activeVehicle->sendCommand(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_SET_MESSAGE_INTERVAL, true /* showError */, MAVLINK_MSG_ID_DEBUG_FLOAT_ARRAY, 100000 /* disable */, 0 /* flight stack */);
 }
 
 QVariantList& CustomPlugin::settingsPages(void)
@@ -142,11 +143,18 @@ void CustomPlugin::_handleVHFPulse(const mavlink_debug_float_array_t& debug_floa
     _beepStrength = pulseStrength;
     emit beepStrengthChanged(_beepStrength);
 
-    _pulseTimeSeconds   = debug_float_array.time_usec / 1000000.0;
+    _pulseTimeSeconds   = *((double *)&debug_float_array.data[0]);
     _pulseSNR           = debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexSNR)];
     _pulseConfirmed     = debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexConfirmedStatus)] > 0;
-    qCDebug(CustomPluginLog) << Qt::fixed << qSetRealNumberPrecision(2) << "PULSE time:snr" << _pulseTimeSeconds << _pulseSNR << debug_float_array.data[static_cast<uint32_t>(PulseIndex::PulseIndexConfirmedStatus)];
-    emit pulseReceived();
+
+    if (qFuzzyCompare(_lastPulseTime, _pulseTimeSeconds)) {
+        // Remove duplicates cause by double forwarding or detection boundary case
+        return;
+    } else {
+        qCDebug(CustomPluginLog) << Qt::fixed << qSetRealNumberPrecision(2) << "PULSE time:snr" << _pulseTimeSeconds << _pulseSNR << _pulseConfirmed;
+        emit pulseReceived();
+    }
+    _lastPulseTime = _pulseTimeSeconds;
 
     _rgPulseValues.append(_beepStrength);
     if (_beepStrength == 0) {
@@ -350,7 +358,7 @@ void CustomPlugin::stopDetection(void)
                     sharedLink->mavlinkChannel(),
                     &msg,
                     &debug_float_array);
-        _sendVHFCommand(vehicle, sharedLink.get(), CommandID::CommandIDStart, msg);
+        _sendVHFCommand(vehicle, sharedLink.get(), CommandID::CommandIDStop, msg);
     }
 }
 

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -388,7 +388,7 @@ void CustomPlugin::airspyHFCapture(void)
                     sharedLink->mavlinkChannel(),
                     &msg,
                     &debug_float_array);
-        _sendVHFCommand(vehicle, sharedLink.get(), CommandID::CommandIDStop, msg);
+        _sendVHFCommand(vehicle, sharedLink.get(), static_cast<CommandID>(6), msg);
     }
 }
 
@@ -418,7 +418,7 @@ void CustomPlugin::airspyMiniCapture(void)
                     sharedLink->mavlinkChannel(),
                     &msg,
                     &debug_float_array);
-        _sendVHFCommand(vehicle, sharedLink.get(), CommandID::CommandIDStop, msg);
+        _sendVHFCommand(vehicle, sharedLink.get(), static_cast<CommandID>(7), msg);
     }
 }
 

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -362,6 +362,66 @@ void CustomPlugin::stopDetection(void)
     }
 }
 
+void CustomPlugin::airspyHFCapture(void)
+{
+    Vehicle* vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
+    if (!vehicle) {
+        qCDebug(CustomPluginLog) << "stopDetection called with no vehicle active";
+        return;
+    }
+
+    mavlink_message_t           msg;
+    mavlink_debug_float_array_t debug_float_array;
+    MAVLinkProtocol*            mavlink             = qgcApp()->toolbox()->mavlinkProtocol();
+    WeakLinkInterfacePtr        weakPrimaryLink     = vehicle->vehicleLinkManager()->primaryLink();
+
+    if (!weakPrimaryLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakPrimaryLink.lock();
+
+        memset(&debug_float_array, 0, sizeof(debug_float_array));
+
+        debug_float_array.array_id = 6;
+
+        mavlink_msg_debug_float_array_encode_chan(
+                    static_cast<uint8_t>(mavlink->getSystemId()),
+                    static_cast<uint8_t>(mavlink->getComponentId()),
+                    sharedLink->mavlinkChannel(),
+                    &msg,
+                    &debug_float_array);
+        _sendVHFCommand(vehicle, sharedLink.get(), CommandID::CommandIDStop, msg);
+    }
+}
+
+void CustomPlugin::airspyMiniCapture(void)
+{
+    Vehicle* vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
+    if (!vehicle) {
+        qCDebug(CustomPluginLog) << "stopDetection called with no vehicle active";
+        return;
+    }
+
+    mavlink_message_t           msg;
+    mavlink_debug_float_array_t debug_float_array;
+    MAVLinkProtocol*            mavlink             = qgcApp()->toolbox()->mavlinkProtocol();
+    WeakLinkInterfacePtr        weakPrimaryLink     = vehicle->vehicleLinkManager()->primaryLink();
+
+    if (!weakPrimaryLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakPrimaryLink.lock();
+
+        memset(&debug_float_array, 0, sizeof(debug_float_array));
+
+        debug_float_array.array_id = 7;
+
+        mavlink_msg_debug_float_array_encode_chan(
+                    static_cast<uint8_t>(mavlink->getSystemId()),
+                    static_cast<uint8_t>(mavlink->getComponentId()),
+                    sharedLink->mavlinkChannel(),
+                    &msg,
+                    &debug_float_array);
+        _sendVHFCommand(vehicle, sharedLink.get(), CommandID::CommandIDStop, msg);
+    }
+}
+
 void CustomPlugin::_sendCommandAndVerify(Vehicle* vehicle, MAV_CMD command, double param1, double param2, double param3, double param4, double param5, double param6, double param7)
 {
     connect(vehicle, &Vehicle::mavCommandResult, this, &CustomPlugin::_mavCommandResult);

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -39,11 +39,13 @@ public:
     Q_PROPERTY(int              missedPulseCount    MEMBER _missedPulseCount        NOTIFY missedPulseCountChanged)
     Q_PROPERTY(int              detectionStatus     MEMBER _detectionStatus         NOTIFY detectionStatusChanged)
 
-    Q_INVOKABLE void startRotation  (void);
-    Q_INVOKABLE void cancelAndReturn(void);
-    Q_INVOKABLE void sendTag        (void);
-    Q_INVOKABLE void startDetection (void);
-    Q_INVOKABLE void stopDetection  (void);
+    Q_INVOKABLE void startRotation      (void);
+    Q_INVOKABLE void cancelAndReturn    (void);
+    Q_INVOKABLE void sendTag            (void);
+    Q_INVOKABLE void startDetection     (void);
+    Q_INVOKABLE void stopDetection      (void);
+    Q_INVOKABLE void airspyHFCapture    (void);
+    Q_INVOKABLE void airspyMiniCapture  (void);
 
     // Overrides from QGCCorePlugin
     QVariantList&       settingsPages           (void) final;

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -125,6 +125,7 @@ private:
     int                     _nextSlice;
     int                     _cSlice;
     int                     _detectionStatus = -1;
+    double                  _lastPulseTime = 0;
 
     qreal                   _beepStrength;
     qreal                   _temp;

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -110,14 +110,20 @@ Item {
     readonly property int actionStartDetection:             26
     readonly property int actionStopDetection:              27
     readonly property int actionStartRotation:              28
+    readonly property int actionAirspyHF:                   29
+    readonly property int actionAirspyMini:                 30
 
     readonly property string startDetectionTitle:           qsTr("Start")
     readonly property string stopDetectionTitle:            qsTr("Stop")
     readonly property string startRotationTitle:            qsTr("Rotate")
+    readonly property string airspyHFTitle:                 qsTr("HF+")
+    readonly property string airspyMiniTitle:               qsTr("Mini")
 
     readonly property string startDetectionMessage:         qsTr("Start pulse detection for the specified tag.")
     readonly property string stopDetectionMessage:          qsTr("Stop all pulse detection.")
     readonly property string startRotationMessage:          qsTr("Start rotation in place.")
+    readonly property string airspyHFMessage:               qsTr("Start capture Airspy HF+.")
+    readonly property string airspyMiniMessage:             qsTr("Start capture Airspy Mini.")
     // End UAV-RT mods
 
     property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
@@ -526,6 +532,16 @@ Item {
             confirmDialog.title = startRotationTitle
             confirmDialog.message = startRotationMessage
             break
+        case actionAirspyHF:
+            confirmDialog.hideTrigger = true
+            confirmDialog.title = airspyHFTitle
+            confirmDialog.message = airspyHFMessage
+            break
+        case actionAirspyMini:
+            confirmDialog.hideTrigger = true
+            confirmDialog.title = airspyMiniTitle
+            confirmDialog.message = airspyMiniMessage
+            break
         // End UAV-RT modes
         default:
             console.warn("Unknown actionCode", actionCode)
@@ -625,6 +641,12 @@ Item {
             break
         case actionStartRotation:
             QGroundControl.corePlugin.startRotation()
+            break
+        case actionAirspyHF:
+            QGroundControl.corePlugin.airspyHFCapture()
+            break
+        case actionAirspyMini:
+            QGroundControl.corePlugin.airspyMiniCapture()
             break
         // End UAV-RT modes
         default:

--- a/src/QmlControls/QGroundControl/FlightDisplay/qmldir
+++ b/src/QmlControls/QGroundControl/FlightDisplay/qmldir
@@ -24,6 +24,8 @@ GuidedActionTakeoff             1.0 GuidedActionTakeoff.qml
 CustomGuidedActionStartDetection      1.0 CustomGuidedActionStartDetection.qml
 CustomGuidedActionStopDetection       1.0 CustomGuidedActionStopDetection.qml
 CustomGuidedActionStartRotation       1.0 CustomGuidedActionStartRotation.qml
+CustomGuidedActionAirspyHF      1.0 CustomGuidedActionAirspyHF.qml
+CustomGuidedActionAirspyMini      1.0 CustomGuidedActionAirspyMini.qml
 GuidedToolStripAction           1.0 GuidedToolStripAction.qml
 MultiVehicleList                1.0 MultiVehicleList.qml
 PreFlightBatteryCheck           1.0 PreFlightBatteryCheck.qml


### PR DESCRIPTION
There are a number of issues here:
* PX4 firmware tracks the DEBUG_FLOAT_ARRAY messages that flow through it and pushes them out on a stream interval. The rate for that interval is 1 a second.
* Depending on the connection type (specifically SiK radios) DEBUG_FLOAT_ARRAY messages are not automatically forwarded through the system
* This steaming thing leads to two problems:
  * The streaming rate is too slow so you lose pulses
  * Depending on the connection type you may get pulses automatically forwarded and then also from the stream leading to duplicates
* Since the only reliable mechanism to get DEBUG_FLOAT_ARRAY to move through the system it requires the following changes:
  * QGC must bump up the stream rate for it so that no messages are lost
  * Pulses which are at the same time stamp must be ignored since they are duplicates caused by the forward strangeness
* Time stamps cannot be stored in a float in DEBUG_FLOAT_ARRAY. Since the timestamps are large numbers you end up with floating point inprecision where the conversion from double to float loses large amounts of precision

In order to work around this I made the following changes:
* QGC set the stream rate for DEBUG_FLOAT_ARRAY on the vehicle to 100 msecs. This way pulses are not lost.
* The pulse timestamp (t_0) must be stored in a double and passed across the wire as a double. In order to do that I'm using index 0/1 of the DEBUG_FLOAT_ARRAY to pass the pulse start time as a double.

I've modified the version of my mavlink controller on the vehicle to do this and tested end to end with QGC and it works.