### PR TITLE
Multi tag support

### DIFF
--- a/custom/TagInfo.txt
+++ b/custom/TagInfo.txt
@@ -1,3 +1,3 @@
 # id, freq_hz, ip_msecs, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
-2, 146000, 2000, 15, 60, 20, 3, 0.005
-3, 146000, 1333, 15, 60, 20, 3, 0.005
+2, 146000000, 2000, 15, 60, 20, 3, 0.005
+3, 146000000, 1333, 15, 60, 20, 3, 0.005

--- a/custom/TagInfo.txt
+++ b/custom/TagInfo.txt
@@ -1,0 +1,3 @@
+# id, freq_hz, ip_msecs, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
+2, 146000, 2000, 15, 60, 20, 3, 0.005
+3, 146000, 1333, 15, 60, 20, 3, 0.005

--- a/custom/custom.pri
+++ b/custom/custom.pri
@@ -70,6 +70,7 @@ SOURCES += \
     $$PWD/src/CustomOptions.cc \
     $$PWD/src/CustomPlugin.cc \
     $$PWD/src/CustomSettings.cc \
+    $$PWD/src/TagInfoLoader.cc \
 
 HEADERS += \
     $$PWD/src/CustomFirmwarePlugin.h \
@@ -77,6 +78,7 @@ HEADERS += \
     $$PWD/src/CustomOptions.h \
     $$PWD/src/CustomPlugin.h \
     $$PWD/src/CustomSettings.h \
+    $$PWD/src/TagInfoLoader.h \
 
 INCLUDEPATH += \
     $$PWD/src \

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -5,6 +5,7 @@
 #include "CustomOptions.h"
 #include "FactSystem.h"
 #include "TunnelProtocol.h"
+#include "TagInfoLoader.h"
 
 #include <QElapsedTimer>
 #include <QGeoCoordinate>
@@ -102,7 +103,7 @@ private:
     double  _pulseTimeSeconds           (void) { return _lastPulseInfo.start_time_seconds; }
     double  _pulseSNR                   (void) { return _lastPulseInfo.snr; }
     bool    _pulseConfirmed             (void) { return _lastPulseInfo.confirmed_status; }
-    void    _sendOneTag                 (void);
+    void    _sendNextTag                (void);
     void    _sendEndTags                (void);
 
     QVariantList            _settingsPages;
@@ -132,6 +133,9 @@ private:
     QmlObjectListModel      _customMapItems;
     QFile                   _pulseLogFile;
     TunnelProtocol::PulseInfo_t _lastPulseInfo;
+
+    TagInfoLoader           _tagInfoLoader;
+    int                     _nextTagToSend;
 };
 
 class PulseRoseMapItem : public QObject

--- a/custom/src/TagInfoLoader.cc
+++ b/custom/src/TagInfoLoader.cc
@@ -88,13 +88,13 @@ bool TagInfoLoader::loadTags(void)
         }
 
         tagValueString              = tagValues[tagValuePosition++];
-        tagInfo.intra_pulse1_msecs  = tagValueString.toUInt(&ok);
+        tagInfo.pulse_width_msecs   = tagValueString.toUInt(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert pulse_width_msecs to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.intra_pulse1_msecs == 0) {
-            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
+        if (tagInfo.pulse_width_msecs == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. pulse_width_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
 
@@ -141,6 +141,8 @@ bool TagInfoLoader::loadTags(void)
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. false_alarm value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
+
+        newTagList.append(tagInfo);
     }
 
     tagList = newTagList;

--- a/custom/src/TagInfoLoader.cc
+++ b/custom/src/TagInfoLoader.cc
@@ -1,0 +1,149 @@
+#include "TagInfoLoader.h"
+#include "QGCApplication.h"
+#include "SettingsManager.h"
+#include "AppSettings.h"
+
+#include <QFile>
+#include <QTextStream>
+
+using namespace TunnelProtocol;
+
+TagInfoLoader::TagInfoLoader(QObject* parent)
+    : QObject(parent)
+{
+
+}
+
+TagInfoLoader::~TagInfoLoader()
+{
+
+}
+
+bool TagInfoLoader::loadTags(void)
+{
+    tagList.clear();
+    QList<TagInfo_t> newTagList;
+
+    QString tagFilename = QString::asprintf("%s/TagInfo.txt",
+                                            qgcApp()->toolbox()->settingsManager()->appSettings()->parameterSavePath().toStdString().c_str());
+    QFile   tagFile(tagFilename);
+
+    if (!tagFile.open(QIODevice::ReadOnly)) {
+        qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Unable to open tag file: %1").arg(tagFilename));
+        return false;
+    }
+
+    QString     tagLine;
+    QTextStream tagStream(&tagFile);
+    uint32_t    lineCount = 0;
+    while (tagStream.readLineInto(&tagLine)) {
+        lineCount++;
+        if (tagLine.startsWith("#")) {
+            continue;
+        }
+
+        int         valueCount = 8;
+        QStringList tagValues = tagLine.split(",");
+        if (tagValues.count() != valueCount) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Does not contain %2 values").arg(lineCount).arg(valueCount));
+            return false;
+        }
+
+        bool        ok;
+        TagInfo_t   tagInfo;
+        QString     tagValueString;
+        int         tagValuePosition = 0;
+
+        tagInfo.header.command = COMMAND_ID_TAG;
+
+        // id, freq_hz, ip_msecs, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
+
+        tagValueString  = tagValues[tagValuePosition++];
+        tagInfo.id      = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert id to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+        if (tagInfo.id <= 1) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Tag ids must be greater than 1").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        tagValueString          = tagValues[tagValuePosition++];
+        tagInfo.frequency_hz    = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert freq_hz to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        tagValueString              = tagValues[tagValuePosition++];
+        tagInfo.intra_pulse1_msecs  = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_msecs to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+        if (tagInfo.intra_pulse1_msecs == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        tagValueString              = tagValues[tagValuePosition++];
+        tagInfo.intra_pulse1_msecs  = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert pulse_width_msecs to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+        if (tagInfo.intra_pulse1_msecs == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        tagValueString                          = tagValues[tagValuePosition++];
+        tagInfo.intra_pulse_uncertainty_msecs   = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_uncertainty_msecs to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+        if (tagInfo.intra_pulse_uncertainty_msecs == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_uncertainty_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        tagValueString                      = tagValues[tagValuePosition++];
+        tagInfo.intra_pulse_jitter_msecs    = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_jitter_msecs to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+        if (tagInfo.intra_pulse_jitter_msecs == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_jitter_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        tagValueString  = tagValues[tagValuePosition++];
+        tagInfo.k       = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert k to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+        if (tagInfo.k == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. k value cannot be 0").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        tagValueString                  = tagValues[tagValuePosition++];
+        tagInfo.false_alarm_probability = tagValueString.toDouble(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert false_alarm to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+        if (tagInfo.false_alarm_probability == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. false_alarm value cannot be 0").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+    }
+
+    tagList = newTagList;
+
+    return true;
+}

--- a/custom/src/TagInfoLoader.h
+++ b/custom/src/TagInfoLoader.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "QGCMAVLink.h"
+#include "TunnelProtocol.h"
+
+#include <QObject>
+
+class TagInfoLoader : public QObject
+{
+    Q_OBJECT
+
+public:
+    TagInfoLoader(QObject* parent = NULL);
+    ~TagInfoLoader();
+
+    bool loadTags(void);
+
+    QList<TunnelProtocol::TagInfo_t> tagList;
+};


### PR DESCRIPTION
* Keeping things simple for now. No UI for tag entry/editing yet, just a file
* QGC loads tag info from a csv file named TagInfo.txt. Example file contents:
```
# id, freq_hz, ip_msecs, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
2, 146000000, 2000, 15, 60, 20, 3, 0.005
3, 146000000, 1333, 15, 60, 20, 3, 0.005
```
* Even/odd pairs of ids should the same tag at different BPM rates
* Lines which start with ```#``` are ignored
* TagInfo.txt file is loaded from ```~/Documents/Tag Tracker Daily/Parameters``` directory
* Example TagInfo.txt file can be found in the ```custom``` directory of the repo
* Clicking Tags button will upload all tags from the file to the vehicle