### PR TITLE
New Pulse display ui

### DIFF
--- a/custom/custom.pri
+++ b/custom/custom.pri
@@ -71,6 +71,7 @@ SOURCES += \
     $$PWD/src/CustomPlugin.cc \
     $$PWD/src/CustomSettings.cc \
     $$PWD/src/TagInfoLoader.cc \
+    $$PWD/src/PulseInfo.cc \
 
 HEADERS += \
     $$PWD/src/CustomFirmwarePlugin.h \
@@ -79,6 +80,7 @@ HEADERS += \
     $$PWD/src/CustomPlugin.h \
     $$PWD/src/CustomSettings.h \
     $$PWD/src/TagInfoLoader.h \
+    $$PWD/src/PulseInfo.h \
 
 INCLUDEPATH += \
     $$PWD/src \

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -6,6 +6,7 @@
 #include "FactSystem.h"
 #include "TunnelProtocol.h"
 #include "TagInfoLoader.h"
+#include "PulseInfo.h"
 
 #include <QElapsedTimer>
 #include <QGeoCoordinate>
@@ -26,14 +27,10 @@ public:
     ~CustomPlugin();
 
     Q_PROPERTY(CustomSettings*  customSettings      MEMBER  _customSettings         CONSTANT)
-    Q_PROPERTY(double           pulseTimeSeconds    READ    _pulseTimeSeconds       NOTIFY pulseReceived)
-    Q_PROPERTY(double           pulseSNR            READ    _pulseSNR               NOTIFY pulseReceived)
-    Q_PROPERTY(bool             pulseConfirmed      READ    _pulseConfirmed         NOTIFY pulseReceived)
     Q_PROPERTY(QList<QList<double>> angleRatios     MEMBER  _rgAngleRatios          NOTIFY angleRatiosChanged)
     Q_PROPERTY(bool             flightMachineActive MEMBER  _flightMachineActive    NOTIFY flightMachineActiveChanged)
-    Q_PROPERTY(int              vehicleFrequency    MEMBER  _vehicleFrequency       NOTIFY vehicleFrequencyChanged)
-    Q_PROPERTY(int              missedPulseCount    MEMBER  _missedPulseCount       NOTIFY missedPulseCountChanged)
-    Q_PROPERTY(int              detectionStatus     MEMBER  _detectionStatus        NOTIFY detectionStatusChanged)
+    Q_PROPERTY(QVariantList     currPulseInfoList   READ    currPulseInfoList       NOTIFY pulseInfoListsChanged)
+    Q_PROPERTY(QVariantList     prevPulseInfoList   READ    prevPulseInfoList       NOTIFY pulseInfoListsChanged)
 
     Q_INVOKABLE void startRotation      (void);
     Q_INVOKABLE void cancelAndReturn    (void);
@@ -42,6 +39,9 @@ public:
     Q_INVOKABLE void stopDetection      (void);
     Q_INVOKABLE void airspyHFCapture    (void);
     Q_INVOKABLE void airspyMiniCapture  (void);
+
+    QVariantList currPulseInfoList(void);
+    QVariantList prevPulseInfoList(void);
 
     // Overrides from QGCCorePlugin
     QVariantList&       settingsPages           (void) final;
@@ -56,10 +56,7 @@ public:
 signals:
     void angleRatiosChanged         (void);
     void flightMachineActiveChanged (bool flightMachineActive);
-    void vehicleFrequencyChanged    (int vehicleFrequency);
-    void missedPulseCountChanged    (int missedPulseCount);
-    void detectionStatusChanged     (int detectionStatus);
-    void pulseReceived              (void);
+    void pulseInfoListsChanged      (void);
 
 private slots:
     void _vehicleStateRawValueChanged   (QVariant rawValue);
@@ -135,6 +132,10 @@ private:
 
     TagInfoLoader           _tagInfoLoader;
     int                     _nextTagToSend;
+
+    QMap<uint32_t, QList<PulseInfo*>>   _prevPulseInfoMap;
+    QMap<uint32_t, QList<PulseInfo*>>   _currPulseInfoMap;
+    QMap<uint32_t, QTime>               _lastPulseTimes;
 };
 
 class PulseRoseMapItem : public QObject

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -68,79 +68,41 @@ Item {
 
         property real _margins: ScreenTools.defaultFontPixelWidth / 2
 
-        ChartView {
-            id:                 chart
-            anchors.fill:       parent
-            antialiasing:       true
-            margins.top:            0
-            margins.bottom:            0
-            margins.left:            0
-            margins.right:            0
-            legend.visible: false
+        QGCFlickable {
+            anchors.fill:   parent
+            contentHeight:  innerColumn.height
 
-            ValueAxis {
-                id:             axisX
-                min:            0
-                max:            100
-                tickCount:      5
-                labelsVisible:  false
-            }
+            ColumnLayout {
+                id:             innerColumn
+                anchors.left:   parent.left
+                anchors.right:  parent.right
 
-            ValueAxis {
-                id:         axisY
-                min:        0
-                max:        12
-                tickCount:  12
-                reverse:    true
-            }
-
-            ScatterSeries {
-                id:             confirmedSeries
-                axisX:          axisX
-                axisY:          axisY
-                markerShape:    ScatterSeries.MarkerShapeCircle
-            }
-
-            ScatterSeries {
-                id:             unConfirmedSeries
-                axisX:          axisX
-                axisY:          axisY
-                markerShape:    ScatterSeries.MarkerShapeRectangle
-                markerSize:     confirmedSeries.markerSize * 0.75
-            }
-
-            Timer {
-                id:         updateTimer
-                interval:   100
-                repeat:     true
-                running:    true
-                onTriggered: {
-                    axisY.min = axisY.min + 0.1
-                    axisY.max = axisY.max + 0.1
+                SectionHeader {
+                    Layout.fillWidth:   true
+                    text:               qsTr("Previous Pulses")
                 }
-            }
 
-            Connections {
-                target: _corePlugin
+                Repeater {
+                    model: _corePlugin.prevPulseInfoList;
 
-                property bool firstPulse:       true
-                property real timeAdjustment:   0
-
-                function onPulseReceived() {
-                    if (firstPulse) {
-                        firstPulse = false
-                        timeAdjustment = _corePlugin.pulseTimeSeconds - axisY.max
+                    QGCLabel {
+                        text: qsTr("id:%1 %2").arg(modelData.tag_id).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
                     }
-                    var adjustedTimeValue = _corePlugin.pulseTimeSeconds - timeAdjustment
-                    if (_corePlugin.pulseConfirmed) {
-                        confirmedSeries.append(_corePlugin.pulseSNR, adjustedTimeValue);
-                    } else {
-                        unConfirmedSeries.append(_corePlugin.pulseSNR, adjustedTimeValue);
-                    }
+                }
 
+                SectionHeader {
+                    Layout.fillWidth:   true
+                    text:               qsTr("Current Pulses")
+                }
+
+                Repeater {
+                    model: _corePlugin.currPulseInfoList;
+
+                    QGCLabel {
+                        text: qsTr("id:%1 %2").arg(modelData.tag_id).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
+                    }
                 }
             }
         }
-
     }
 }

--- a/custom/src/PulseInfo.cc
+++ b/custom/src/PulseInfo.cc
@@ -1,0 +1,13 @@
+#include "PulseInfo.h"
+
+PulseInfo::PulseInfo(TunnelProtocol::PulseInfo_t pulseInfo, QObject* parent)
+    : QObject   (parent)
+    , _pulseInfo(pulseInfo)
+{
+
+}
+
+PulseInfo::~PulseInfo()
+{
+
+}

--- a/custom/src/PulseInfo.h
+++ b/custom/src/PulseInfo.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "QGCMAVLink.h"
+#include "TunnelProtocol.h"
+
+#include <QObject>
+
+class PulseInfo : public QObject
+{
+    Q_OBJECT
+
+public:
+    PulseInfo(TunnelProtocol::PulseInfo_t pulseInfo, QObject* parent = NULL);
+    ~PulseInfo();
+
+    Q_PROPERTY(uint     tag_id              READ tag_id             CONSTANT)
+    Q_PROPERTY(uint     frequency_hz        READ frequency_hz       CONSTANT)
+    Q_PROPERTY(double   start_time_seconds  READ start_time_seconds CONSTANT)
+    Q_PROPERTY(double   snr                 READ snr                CONSTANT)
+    Q_PROPERTY(uint     group_ind           READ group_ind          CONSTANT)
+
+    uint    tag_id             (void) { return _pulseInfo.tag_id; }
+    uint    frequency_hz       (void) { return _pulseInfo.frequency_hz; }
+    double  start_time_seconds (void) { return _pulseInfo.start_time_seconds; }
+    double  snr                (void) { return _pulseInfo.snr; }
+    uint    group_ind          (void) { return _pulseInfo.group_ind; }
+
+private:
+    TunnelProtocol::PulseInfo_t _pulseInfo;
+};

--- a/custom/src/TagInfoLoader.cc
+++ b/custom/src/TagInfoLoader.cc
@@ -21,8 +21,9 @@ TagInfoLoader::~TagInfoLoader()
 
 bool TagInfoLoader::loadTags(void)
 {
-    tagList.clear();
-    QList<TagInfo_t> newTagList;
+    _tagInfoMap.clear();
+
+    TagInfoMap_t newTagInfoMap;
 
     QString tagFilename = QString::asprintf("%s/TagInfo.txt",
                                             qgcApp()->toolbox()->settingsManager()->appSettings()->parameterSavePath().toStdString().c_str());
@@ -142,10 +143,23 @@ bool TagInfoLoader::loadTags(void)
             return false;
         }
 
-        newTagList.append(tagInfo);
+        newTagInfoMap[tagInfo.id] = tagInfo;
     }
 
-    tagList = newTagList;
+    _tagInfoMap = newTagInfoMap;
 
     return true;
+}
+
+QList<TunnelProtocol::TagInfo_t> TagInfoLoader::getTagList(void)
+{
+    QList<TunnelProtocol::TagInfo_t> tagList;
+
+    TagInfoMap_t::const_iterator iter = _tagInfoMap.constBegin();
+    while (iter != _tagInfoMap.constEnd()) {
+        tagList.append(iter.value());
+        ++iter;
+    }
+
+    return tagList;
 }

--- a/custom/src/TagInfoLoader.h
+++ b/custom/src/TagInfoLoader.h
@@ -4,6 +4,7 @@
 #include "TunnelProtocol.h"
 
 #include <QObject>
+#include <QMap>
 
 class TagInfoLoader : public QObject
 {
@@ -13,7 +14,14 @@ public:
     TagInfoLoader(QObject* parent = NULL);
     ~TagInfoLoader();
 
-    bool loadTags(void);
+    typedef QList<TunnelProtocol::TagInfo_t> TagList_t;
 
-    QList<TunnelProtocol::TagInfo_t> tagList;
+    bool                        loadTags    (void);
+    TagList_t                   getTagList  (void);
+    TunnelProtocol::TagInfo_t   getTagInfo  (uint32_t tag_id) { return _tagInfoMap[tag_id]; }
+
+private:
+    typedef QMap<uint32_t, TunnelProtocol::TagInfo_t> TagInfoMap_t;
+
+    TagInfoMap_t _tagInfoMap;
 };


### PR DESCRIPTION
Just a simple thing which works better than for testing. QGC assumes that pulses with the same tag that receive at about the same time make up a group. (The TunnelProtocol::PulseInfo_t is missing the concept of something like a group sequence count is thingy). As the groups of pulses come in the current set and the previous set are shown on the simple. Very simple, just tag id and snr.

At some point I"ll step back and make something real and end user focused. But this is good for testing.

This is multi-rate example. The two tag ids are the same tag at different rates.
![Screen Shot 2023-02-27 at 12 52 39](https://user-images.githubusercontent.com/5876851/221683390-9ed2f4e4-7317-4db9-b66d-086edb63d1dc.png)
