### PR TITLE
Tag name, rate name support

### DIFF
--- a/custom/TagInfo.txt
+++ b/custom/TagInfo.txt
@@ -1,3 +1,4 @@
-# id, freq_hz, ip_msecs, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
-2, 146000000, 1333, 15, 60, 20, 3, 0.005
-3, 146000000, 2000, 15, 60, 20, 3, 0.005
+# id, name, freq_hz, ip_msecs_1, ip_msecs_1_id, ip_msecs_2, ip_msecs_2_id, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
+# Note: id's start at 2 and must be even numbers
+2,Telonics,146000000,1333,M,2000,R,15,60,20,3,0.005
+

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -86,7 +86,7 @@ Item {
                     model: _corePlugin.prevPulseInfoList;
 
                     QGCLabel {
-                        text: qsTr("id:%1 %2").arg(modelData.tag_id).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
+                        text: qsTr("%1:%2 %3").arg(modelData.name).arg(modelData.rateChar).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
                     }
                 }
 
@@ -99,7 +99,7 @@ Item {
                     model: _corePlugin.currPulseInfoList;
 
                     QGCLabel {
-                        text: qsTr("id:%1 %2").arg(modelData.tag_id).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
+                        text: qsTr("%1:%2 %3").arg(modelData.name).arg(modelData.rateChar).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
                     }
                 }
             }

--- a/custom/src/PulseInfo.cc
+++ b/custom/src/PulseInfo.cc
@@ -1,8 +1,10 @@
 #include "PulseInfo.h"
 
-PulseInfo::PulseInfo(TunnelProtocol::PulseInfo_t pulseInfo, QObject* parent)
+PulseInfo::PulseInfo(TunnelProtocol::PulseInfo_t pulseInfo, QString& name, QString& rateChar, QObject* parent)
     : QObject   (parent)
     , _pulseInfo(pulseInfo)
+    , _name     (name)
+    , _rateChar (rateChar)
 {
 
 }

--- a/custom/src/PulseInfo.h
+++ b/custom/src/PulseInfo.h
@@ -10,21 +10,27 @@ class PulseInfo : public QObject
     Q_OBJECT
 
 public:
-    PulseInfo(TunnelProtocol::PulseInfo_t pulseInfo, QObject* parent = NULL);
+    PulseInfo(TunnelProtocol::PulseInfo_t pulseInfo, QString& name, QString& rateChar, QObject* parent = NULL);
     ~PulseInfo();
 
     Q_PROPERTY(uint     tag_id              READ tag_id             CONSTANT)
+    Q_PROPERTY(QString  name                READ name               CONSTANT)
+    Q_PROPERTY(QString  rateChar            READ rateChar               CONSTANT)
     Q_PROPERTY(uint     frequency_hz        READ frequency_hz       CONSTANT)
     Q_PROPERTY(double   start_time_seconds  READ start_time_seconds CONSTANT)
     Q_PROPERTY(double   snr                 READ snr                CONSTANT)
     Q_PROPERTY(uint     group_ind           READ group_ind          CONSTANT)
 
-    uint    tag_id             (void) { return _pulseInfo.tag_id; }
-    uint    frequency_hz       (void) { return _pulseInfo.frequency_hz; }
-    double  start_time_seconds (void) { return _pulseInfo.start_time_seconds; }
-    double  snr                (void) { return _pulseInfo.snr; }
-    uint    group_ind          (void) { return _pulseInfo.group_ind; }
+    uint    tag_id              (void) { return _pulseInfo.tag_id; }
+    QString name                (void) { return _name; }
+    QString rateChar            (void) { return _rateChar; }
+    uint    frequency_hz        (void) { return _pulseInfo.frequency_hz; }
+    double  start_time_seconds  (void) { return _pulseInfo.start_time_seconds; }
+    double  snr                 (void) { return _pulseInfo.snr; }
+    uint    group_ind           (void) { return _pulseInfo.group_ind; }
 
 private:
     TunnelProtocol::PulseInfo_t _pulseInfo;
+    QString                     _name;
+    QString                     _rateChar;
 };

--- a/custom/src/TagInfoLoader.cc
+++ b/custom/src/TagInfoLoader.cc
@@ -34,116 +34,147 @@ bool TagInfoLoader::loadTags(void)
         return false;
     }
 
+
     QString     tagLine;
     QTextStream tagStream(&tagFile);
     uint32_t    lineCount = 0;
+    QString     lineFormat = "id, name, freq_hz, ip_msecs_1, ip_msecs_1_id, ip_msecs_2, ip_msecs_2_id, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm";
     while (tagStream.readLineInto(&tagLine)) {
         lineCount++;
         if (tagLine.startsWith("#")) {
             continue;
         }
+        if (tagLine.length() == 0) {
+            continue;
+        }
 
-        int         valueCount = 8;
+        int         valueCount = lineFormat.split(",").count();
         QStringList tagValues = tagLine.split(",");
         if (tagValues.count() != valueCount) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Does not contain %2 values").arg(lineCount).arg(valueCount));
             return false;
         }
 
-        bool        ok;
-        TagInfo_t   tagInfo;
-        QString     tagValueString;
-        int         tagValuePosition = 0;
+        bool                ok;
+        ExtendedTagInfo_t   extTagInfo;
+        QString             tagValueString;
+        int                 tagValuePosition = 0;
 
-        tagInfo.header.command = COMMAND_ID_TAG;
+        extTagInfo.tagInfo.header.command = COMMAND_ID_TAG;
 
         // id, freq_hz, ip_msecs, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
 
-        tagValueString  = tagValues[tagValuePosition++];
-        tagInfo.id      = tagValueString.toUInt(&ok);
+        tagValueString          = tagValues[tagValuePosition++];
+        extTagInfo.tagInfo.id   = tagValueString.toUInt(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert id to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.id <= 1) {
+        if (extTagInfo.tagInfo.id <= 1) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Tag ids must be greater than 1").arg(lineCount).arg(tagValueString));
             return false;
         }
+        if (extTagInfo.tagInfo.id % 2) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Tag ids must be even numbers").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        extTagInfo.name = tagValues[tagValuePosition++];
+        if (extTagInfo.name.length() == 0) {
+            extTagInfo.name.setNum(extTagInfo.tagInfo.id);
+        }
 
         tagValueString          = tagValues[tagValuePosition++];
-        tagInfo.frequency_hz    = tagValueString.toUInt(&ok);
+        extTagInfo.tagInfo.frequency_hz    = tagValueString.toUInt(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert freq_hz to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
 
         tagValueString              = tagValues[tagValuePosition++];
-        tagInfo.intra_pulse1_msecs  = tagValueString.toUInt(&ok);
+        extTagInfo.tagInfo.intra_pulse1_msecs  = tagValueString.toUInt(&ok);
         if (!ok) {
-            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_msecs to uint.").arg(lineCount).arg(tagValueString));
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_msecs_1 to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.intra_pulse1_msecs == 0) {
-            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
+        if (extTagInfo.tagInfo.intra_pulse1_msecs == 0) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_msecs_1 value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
 
+        extTagInfo.ip_msecs_1_id = tagValues[tagValuePosition++];
+        if (extTagInfo.ip_msecs_1_id.length() == 0) {
+            extTagInfo.ip_msecs_1_id = "-";
+        }
+
         tagValueString              = tagValues[tagValuePosition++];
-        tagInfo.pulse_width_msecs   = tagValueString.toUInt(&ok);
+        extTagInfo.tagInfo.intra_pulse2_msecs  = tagValueString.toUInt(&ok);
+        if (!ok) {
+            qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_msecs_2 to uint.").arg(lineCount).arg(tagValueString));
+            return false;
+        }
+
+        extTagInfo.ip_msecs_2_id = tagValues[tagValuePosition++];
+        if (extTagInfo.ip_msecs_2_id.length() == 0) {
+            extTagInfo.ip_msecs_2_id = "-";
+        }
+
+        tagValueString              = tagValues[tagValuePosition++];
+        extTagInfo.tagInfo.pulse_width_msecs   = tagValueString.toUInt(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert pulse_width_msecs to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.pulse_width_msecs == 0) {
+        if (extTagInfo.tagInfo.pulse_width_msecs == 0) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. pulse_width_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
 
         tagValueString                          = tagValues[tagValuePosition++];
-        tagInfo.intra_pulse_uncertainty_msecs   = tagValueString.toUInt(&ok);
+        extTagInfo.tagInfo.intra_pulse_uncertainty_msecs   = tagValueString.toUInt(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_uncertainty_msecs to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.intra_pulse_uncertainty_msecs == 0) {
+        if (extTagInfo.tagInfo.intra_pulse_uncertainty_msecs == 0) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_uncertainty_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
 
         tagValueString                      = tagValues[tagValuePosition++];
-        tagInfo.intra_pulse_jitter_msecs    = tagValueString.toUInt(&ok);
+        extTagInfo.tagInfo.intra_pulse_jitter_msecs    = tagValueString.toUInt(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert ip_jitter_msecs to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.intra_pulse_jitter_msecs == 0) {
+        if (extTagInfo.tagInfo.intra_pulse_jitter_msecs == 0) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. ip_jitter_msecs value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
 
         tagValueString  = tagValues[tagValuePosition++];
-        tagInfo.k       = tagValueString.toUInt(&ok);
+        extTagInfo.tagInfo.k       = tagValueString.toUInt(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert k to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.k == 0) {
+        if (extTagInfo.tagInfo.k == 0) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. k value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
 
         tagValueString                  = tagValues[tagValuePosition++];
-        tagInfo.false_alarm_probability = tagValueString.toDouble(&ok);
+        extTagInfo.tagInfo.false_alarm_probability = tagValueString.toDouble(&ok);
         if (!ok) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. Unable to convert false_alarm to uint.").arg(lineCount).arg(tagValueString));
             return false;
         }
-        if (tagInfo.false_alarm_probability == 0) {
+        if (extTagInfo.tagInfo.false_alarm_probability == 0) {
             qgcApp()->showAppMessage(QStringLiteral("TagInfoLoader: Line #%1 Value:'%2'. false_alarm value cannot be 0").arg(lineCount).arg(tagValueString));
             return false;
         }
 
-        newTagInfoMap[tagInfo.id] = tagInfo;
+        newTagInfoMap[extTagInfo.tagInfo.id] = extTagInfo;
     }
 
     _tagInfoMap = newTagInfoMap;
@@ -151,9 +182,9 @@ bool TagInfoLoader::loadTags(void)
     return true;
 }
 
-QList<TunnelProtocol::TagInfo_t> TagInfoLoader::getTagList(void)
+TagInfoLoader::TagList_t TagInfoLoader::getTagList(void)
 {
-    QList<TunnelProtocol::TagInfo_t> tagList;
+    TagList_t tagList;
 
     TagInfoMap_t::const_iterator iter = _tagInfoMap.constBegin();
     while (iter != _tagInfoMap.constEnd()) {

--- a/custom/src/TagInfoLoader.h
+++ b/custom/src/TagInfoLoader.h
@@ -14,14 +14,21 @@ public:
     TagInfoLoader(QObject* parent = NULL);
     ~TagInfoLoader();
 
-    typedef QList<TunnelProtocol::TagInfo_t> TagList_t;
+    typedef struct {
+        TunnelProtocol::TagInfo_t   tagInfo;
+        QString                     name;
+        QString                     ip_msecs_1_id;
+        QString                     ip_msecs_2_id;
+    } ExtendedTagInfo_t;
 
-    bool                        loadTags    (void);
-    TagList_t                   getTagList  (void);
-    TunnelProtocol::TagInfo_t   getTagInfo  (uint32_t tag_id) { return _tagInfoMap[tag_id]; }
+    typedef QList<ExtendedTagInfo_t> TagList_t;
+
+    bool                loadTags    (void);
+    TagList_t           getTagList  (void);
+    ExtendedTagInfo_t   getTagInfo  (uint32_t tag_id) { return _tagInfoMap[tag_id]; }
 
 private:
-    typedef QMap<uint32_t, TunnelProtocol::TagInfo_t> TagInfoMap_t;
+    typedef QMap<uint32_t, ExtendedTagInfo_t> TagInfoMap_t;
 
     TagInfoMap_t _tagInfoMap;
 };


### PR DESCRIPTION
Changed the structure of the TagInfo.txt file.:
* Tags can have names. If name is not provided it will use the id as the name
* There is only a single even numbered entry for multi-rate tags. QGC will split this into even/odd tag sending on the way out.
* There are single character identifiers for the two rates

QGC will now use the names for display in the ui:
![Screen Shot 2023-03-01 at 10 24 19](https://user-images.githubusercontent.com/5876851/222230952-f4bfb2f9-b25e-4491-a5b3-4960462c1027.png)

Example TagInfo.txt:
```
# id, name, freq_hz, ip_msecs_1, ip_msecs_1_id, ip_msecs_2, ip_msecs_2_id, pulse_width_msecs, ip_uncertainty_msecs, ip_jitter_msecs, k, false_alarm
# Note: id's start at 2 and must be even numbers
2,Telonics,146000000,1333,M,2000,R,15,60,20,3,0.005
```