### PR TITLE
Tuner support

### DIFF
--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -204,13 +204,17 @@ void CustomPlugin::_handleTunnelPulse(const mavlink_tunnel_t& tunnel)
 
                 // Move the curr group of pulses to prev
                 _prevPulseInfoMap[pulseInfo.tag_id] = _currPulseInfoMap[pulseInfo.tag_id];
+                _prevLastTimeMap [pulseInfo.tag_id] = QTime::currentTime();
                 _currPulseInfoMap.remove(pulseInfo.tag_id);
+                _currLastTimeMap.remove(pulseInfo.tag_id);
             }
 
             _currPulseInfoMap[pulseInfo.tag_id].append(new PulseInfo(pulseInfo, tagName, tagRateChar, this));
+            _currLastTimeMap[pulseInfo.tag_id] = QTime::currentTime();
         } else {
             // We've never seen this tag before so we just add directly to current
             _currPulseInfoMap[pulseInfo.tag_id].append(new PulseInfo(pulseInfo, tagName, tagRateChar, this));
+            _currLastTimeMap[pulseInfo.tag_id] = QTime::currentTime();
         }
 
         emit pulseInfoListsChanged();
@@ -354,7 +358,11 @@ void CustomPlugin::startDetection(void)
 {
     StartDetectionInfo_t startDetectionInfo;
 
-    startDetectionInfo.header.command = COMMAND_ID_START_DETECTION;
+    memset(&startDetectionInfo, 0, sizeof(startDetectionInfo));
+
+    startDetectionInfo.header.command               = COMMAND_ID_START_DETECTION;
+    startDetectionInfo.radio_center_frequency_hz    = _tagInfoList.radioCenterHz();
+
     _sendTunnelCommand((uint8_t*)&startDetectionInfo, sizeof(startDetectionInfo));
 }
 

--- a/custom/src/CustomPlugin.cc
+++ b/custom/src/CustomPlugin.cc
@@ -108,13 +108,14 @@ bool CustomPlugin::mavlinkMessage(Vehicle*, LinkInterface*, mavlink_message_t me
 
 void CustomPlugin::_handleTunnelHeartbeat(const mavlink_tunnel_t& tunnel)
 {
+    static uint32_t counter = 0;
+
     Heartbeat_t heartbeat;
 
     memcpy(&heartbeat, tunnel.payload, sizeof(heartbeat));
 
     switch (heartbeat.system_id) {
     case HEARTBEAT_SYSTEM_MAVLINKCONTROLLER:
-        static uint32_t counter = 0;
         qCDebug(CustomPluginLog) << "HEARTBEAT from MavlinkTagController" << counter++;
         break;
     case HEARTBEAT_SYSTEM_CHANNELIZER:

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -136,7 +136,10 @@ private:
 
     QMap<uint32_t, QList<PulseInfo*>>   _prevPulseInfoMap;
     QMap<uint32_t, QList<PulseInfo*>>   _currPulseInfoMap;
+    QMap<uint32_t, QTime>               _prevLastTimeMap;
+    QMap<uint32_t, QTime>               _currLastTimeMap;
     QMap<uint32_t, uint32_t>            _lastGroupSeqCounts;
+
 };
 
 class PulseRoseMapItem : public QObject

--- a/custom/src/TagInfoList.h
+++ b/custom/src/TagInfoList.h
@@ -16,21 +16,24 @@ typedef struct {
 class TagInfoList : public QList<ExtendedTagInfo_t>
 {
 public:
+    TagInfoList();
+
     bool                loadTags        (void);
     ExtendedTagInfo_t   getTagInfo      (uint32_t tag_id);
     uint32_t            radioCenterHz   () { return _radioCenterHz; }
 
 private:
     bool _channelizerTuner  ();
-    void _printChannelMap   (const int centerFreq, const QVector<int>& requestedFreqsHz);
+    void _printChannelMap   (const uint32_t centerFreqHz, const QVector<uint32_t>& wrappedRequestedFreqsHz);
     int  _firstChannelFreqHz(const int centerFreq);
 
-    uint32_t    _radioCenterHz      = 0;
+    uint32_t            _radioCenterHz      = 0;
+    QVector<uint32_t>   _channelBucketCenters;
 
-    static const int   _sampleRateHz       = 100000;
-    static const int   _nChannels          = 10;
-    static const int   _fullBwHz           = _sampleRateHz;
-    static const int   _halfBwHz           = _fullBwHz / 2;
-    static const int   _channelBwHz        = _sampleRateHz / _nChannels;
-    static const int   _halfChannelBwHz    = _channelBwHz / 2;
+    static const uint32_t   _sampleRateHz       = 375000;
+    static const uint       _nChannels          = 100;
+    static const uint32_t   _fullBwHz           = _sampleRateHz;
+    static const uint32_t   _halfBwHz           = _fullBwHz / 2;
+    static const uint32_t   _channelBwHz        = _sampleRateHz / _nChannels;
+    static const uint32_t   _halfChannelBwHz    = _channelBwHz / 2;
 };


### PR DESCRIPTION
Tuner is now written in C++ and part of QGC. This requires additional changes to the tunnel protocol to be able to push up the information from the tuner to the vehicle. 

Specifically:
* Add `channelizer_channel_number` and `channelizer_channel_center_frequency_hz` to TagInfo_t. This gives the vehicle side all the info it needs to write the detector config files.
* Add `radio_center_frequency_hz` to StartDetectionInfo_t. This allows the vehicle to know the radio center for airspy.