### PR TITLE
Pulse log show in toolbar indicator

### DIFF
--- a/custom/custom.pri
+++ b/custom/custom.pri
@@ -72,6 +72,7 @@ SOURCES += \
     $$PWD/src/CustomSettings.cc \
     $$PWD/src/TagInfoList.cc \
     $$PWD/src/PulseInfo.cc \
+    $$PWD/src/PulseInfoList.cc \
 
 HEADERS += \
     $$PWD/src/CustomFirmwarePlugin.h \
@@ -81,6 +82,7 @@ HEADERS += \
     $$PWD/src/CustomSettings.h \
     $$PWD/src/TagInfoList.h \
     $$PWD/src/PulseInfo.h \
+    $$PWD/src/PulseInfoList.h \
 
 INCLUDEPATH += \
     $$PWD/src \

--- a/custom/custom.qrc
+++ b/custom/custom.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/qml">
+        <file alias="PulseLogIndicator.qml">src/PulseLogIndicator.qml</file>
         <file alias="CustomSettings.qml">src/CustomSettings.qml</file>
         <file alias="CustomPulseRoseMapItem.qml">src/CustomPulseRoseMapItem.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewToolStripActionList.qml">src/CustomFlyViewToolStripActionList.qml</file>

--- a/custom/src/CustomFirmwarePlugin.cc
+++ b/custom/src/CustomFirmwarePlugin.cc
@@ -4,3 +4,19 @@ CustomFirmwarePlugin::CustomFirmwarePlugin(void)
 {
 
 }
+
+const QVariantList& CustomFirmwarePlugin::toolIndicators(const Vehicle*)
+{
+    //-- Default list of indicators for all vehicles.
+    if(_toolIndicatorList.size() == 0) {
+        _toolIndicatorList = QVariantList({
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/qml/PulseLogIndicator.qml")),
+        });
+    }
+    return _toolIndicatorList;
+}
+

--- a/custom/src/CustomFirmwarePlugin.h
+++ b/custom/src/CustomFirmwarePlugin.h
@@ -11,6 +11,7 @@ public:
     CustomFirmwarePlugin(void);
 
     // FirmwarePlugin overrides
+    const QVariantList& toolIndicators(const Vehicle* vehicle) final;
 
 private:
     QVariantList _toolIndicatorList;

--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -29,8 +29,7 @@ public:
     Q_PROPERTY(CustomSettings*  customSettings      MEMBER  _customSettings         CONSTANT)
     Q_PROPERTY(QList<QList<double>> angleRatios     MEMBER  _rgAngleRatios          NOTIFY angleRatiosChanged)
     Q_PROPERTY(bool             flightMachineActive MEMBER  _flightMachineActive    NOTIFY flightMachineActiveChanged)
-    Q_PROPERTY(QVariantList     currPulseInfoList   READ    currPulseInfoList       NOTIFY pulseInfoListsChanged)
-    Q_PROPERTY(QVariantList     prevPulseInfoList   READ    prevPulseInfoList       NOTIFY pulseInfoListsChanged)
+    Q_PROPERTY(QVariantList     pulseLog            MEMBER  _pulseLog               NOTIFY pulseLogChanged)
 
     Q_INVOKABLE void startRotation      (void);
     Q_INVOKABLE void cancelAndReturn    (void);
@@ -39,9 +38,6 @@ public:
     Q_INVOKABLE void stopDetection      (void);
     Q_INVOKABLE void airspyHFCapture    (void);
     Q_INVOKABLE void airspyMiniCapture  (void);
-
-    QVariantList currPulseInfoList(void);
-    QVariantList prevPulseInfoList(void);
 
     // Overrides from QGCCorePlugin
     QVariantList&       settingsPages           (void) final;
@@ -57,6 +53,7 @@ signals:
     void angleRatiosChanged         (void);
     void flightMachineActiveChanged (bool flightMachineActive);
     void pulseInfoListsChanged      (void);
+    void pulseLogChanged            ();
 
 private slots:
     void _vehicleStateRawValueChanged   (QVariant rawValue);
@@ -103,6 +100,7 @@ private:
     bool    _pulseConfirmed             (void) { return _lastPulseInfo.confirmed_status; }
     void    _sendNextTag                (void);
     void    _sendEndTags                (void);
+    void    _resetPulseLog              (void);
 
     QVariantList            _settingsPages;
     QVariantList            _instrumentPages;
@@ -131,15 +129,10 @@ private:
     QFile                   _pulseLogFile;
     TunnelProtocol::PulseInfo_t _lastPulseInfo;
 
-    TagInfoList           _tagInfoList;
+    TagInfoList             _tagInfoList;
     TagInfoList::const_iterator _nextTagToSend;
 
-    QMap<uint32_t, QList<PulseInfo*>>   _prevPulseInfoMap;
-    QMap<uint32_t, QList<PulseInfo*>>   _currPulseInfoMap;
-    QMap<uint32_t, QTime>               _prevLastTimeMap;
-    QMap<uint32_t, QTime>               _currLastTimeMap;
-    QMap<uint32_t, uint32_t>            _lastGroupSeqCounts;
-
+    QVariantList            _pulseLog;
 };
 
 class PulseRoseMapItem : public QObject

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -58,51 +58,12 @@ Item {
         bottomEdgeRightInset:       0
     }
 
-    Rectangle {
+    /*Rectangle {
         width:                  parentToolInsets.rightEdgeTopInset
         anchors.topMargin:      parentToolInsets.topEdgeRightInset
         anchors.bottom:         parent.bottom
         anchors.top:            parent.top
         anchors.right:          parent.right
         color:                  "white"
-
-        property real _margins: ScreenTools.defaultFontPixelWidth / 2
-
-        QGCFlickable {
-            anchors.fill:   parent
-            contentHeight:  innerColumn.height
-
-            ColumnLayout {
-                id:             innerColumn
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-
-                SectionHeader {
-                    Layout.fillWidth:   true
-                    text:               qsTr("Previous Pulses")
-                }
-
-                Repeater {
-                    model: _corePlugin.prevPulseInfoList;
-
-                    QGCLabel {
-                        text: qsTr("%1:%2 %3").arg(modelData.name).arg(modelData.rateChar).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
-                    }
-                }
-
-                SectionHeader {
-                    Layout.fillWidth:   true
-                    text:               qsTr("Current Pulses")
-                }
-
-                Repeater {
-                    model: _corePlugin.currPulseInfoList;
-
-                    QGCLabel {
-                        text: qsTr("%1:%2 %3").arg(modelData.name).arg(modelData.rateChar).arg(modelData.snr.toLocaleString(Qt.locale("en_US"), 'f', 3));
-                    }
-                }
-            }
-        }
-    }
+    }*/
 }

--- a/custom/src/PulseInfo.h
+++ b/custom/src/PulseInfo.h
@@ -20,6 +20,7 @@ public:
     Q_PROPERTY(double   start_time_seconds  READ start_time_seconds CONSTANT)
     Q_PROPERTY(double   snr                 READ snr                CONSTANT)
     Q_PROPERTY(uint     group_ind           READ group_ind          CONSTANT)
+    Q_PROPERTY(bool     confirmed           READ confirmed          CONSTANT)
 
     uint    tag_id              (void) { return _pulseInfo.tag_id; }
     QString name                (void) { return _name; }
@@ -28,6 +29,7 @@ public:
     double  start_time_seconds  (void) { return _pulseInfo.start_time_seconds; }
     double  snr                 (void) { return _pulseInfo.snr; }
     uint    group_ind           (void) { return _pulseInfo.group_ind; }
+    bool    confirmed           (void) { return _pulseInfo.confirmed_status; } 
 
 private:
     TunnelProtocol::PulseInfo_t _pulseInfo;

--- a/custom/src/PulseInfoList.cc
+++ b/custom/src/PulseInfoList.cc
@@ -1,0 +1,15 @@
+#include "PulseInfoList.h"
+
+PulseInfoList::PulseInfoList(uint tagId, QString& tagName, uint tagFreqHz, QObject* parent)
+    : QmlObjectListModel(parent)
+    , _tagId    (tagId)
+    , _tagName  (tagName)
+    , _tagFreqHz(tagFreqHz)
+{
+
+}
+
+PulseInfoList::~PulseInfoList()
+{
+
+}

--- a/custom/src/PulseInfoList.h
+++ b/custom/src/PulseInfoList.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "QmlObjectListModel.h"
+
+class PulseInfoList : public QmlObjectListModel
+{
+    Q_OBJECT
+
+public:
+    PulseInfoList(uint tagId, QString& tagName, uint tagFreqHz, QObject* parent = NULL);
+    ~PulseInfoList();
+
+    Q_PROPERTY(uint     tagId     READ      tagId       CONSTANT)
+    Q_PROPERTY(QString  tagName   MEMBER    _tagName   CONSTANT)
+    Q_PROPERTY(uint     tagFreqHz MEMBER    _tagFreqHz CONSTANT)
+
+    uint tagId() const { return _tagId; }
+
+private:
+    uint    _tagId;
+    QString _tagName;
+    uint    _tagFreqHz;
+};

--- a/custom/src/PulseLogIndicator.qml
+++ b/custom/src/PulseLogIndicator.qml
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.11
+import QtQuick.Layouts  1.11
+import QtQuick.Controls 2.15
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.Palette               1.0
+import MAVLink                              1.0
+
+Item {
+    id:             _root
+    anchors.top:    parent.top
+    anchors.bottom: parent.bottom
+    width:          indicator.width
+
+    property bool showIndicator: true
+
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    Rectangle {
+        id:             indicator
+        anchors.top:    parent.top
+        anchors.bottom: parent.bottom
+        width:          ScreenTools.defaultFontPixelHeight * 5
+        color:          "green"  
+
+    }
+    MouseArea {
+        anchors.fill:   parent
+        onClicked:      mainWindow.showIndicatorPopup(_root, indicatorPopup)
+    }
+
+    Component {
+        id: indicatorPopup
+
+        Rectangle {
+            id:         popupRect
+            width:      mainWindow.width * 0.75
+            height:     mainWindow.height
+            color:          "white"
+
+            QGCFlickable {
+                anchors.fill:   parent
+                contentHeight:  lowLayout.height
+                
+                Flow {
+                    id:             flowLayout
+                    anchors.fill:   parent
+                    
+                    Repeater {
+                        model: QGroundControl.corePlugin.pulseLog
+
+                        Row {
+                            spacing: ScreenTools.defaultFontPixelWidth * 2
+
+                            Column {
+                                height: popupRect.height / 2
+                                clip:   true
+
+                                QGCLabel { text: modelData.tagName + " - " + modelData.tagId }
+                                QGCLabel { text: modelData.tagFreqHz }
+
+                                Repeater {
+                                    model: modelData
+
+                                    QGCLabel { text: object.rateChar + ": " + object.snr.toFixed(1) }
+                                }
+                            }
+
+                            Item {
+                                width:  1
+                                height: 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -42,6 +42,12 @@ Row {
             anchors.bottom:     parent.bottom
             source:             modelData
             visible:            item.showIndicator
+
+            onStatusChanged: {
+                if (status == Loader.Error) {
+                    console.error("MainToolBarIndicators - Failed to load", source)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
![Screen Shot 2023-03-11 at 11 06 47](https://user-images.githubusercontent.com/5876851/224507140-f820db74-262f-4f4d-9ffb-db717d5fbf01.png)

The big green block is a WIP system status display. For now it always green.

If you click it you get this:
![Screen Shot 2023-03-11 at 11 06 30](https://user-images.githubusercontent.com/5876851/224507170-2cdb66c7-6b07-45e7-8bb8-09744afaf6da.png)

Which show a log of the latest received confirmed pulses. This example shows 5 multi-rate tags running.