### PR TITLE
CSV logging updates

### DIFF
--- a/custom/src/CustomPlugin.h
+++ b/custom/src/CustomPlugin.h
@@ -108,8 +108,6 @@ private:
     int     _rawPulseToPct              (double rawPulse);
     void    _sendTunnelCommand          (uint8_t* payload, size_t payloadSize);
     QString _tunnelCommandIdToText      (uint32_t command);
-    void    _logPulseToFile             (const mavlink_tunnel_t& tunnel);
-    void    _logRotateStartStopToFile   (bool start);
     double  _pulseTimeSeconds           (void) { return _lastPulseInfo.start_time_seconds; }
     double  _pulseSNR                   (void) { return _lastPulseInfo.snr; }
     bool    _pulseConfirmed             (void) { return _lastPulseInfo.confirmed_status; }
@@ -124,6 +122,14 @@ private:
     void    _resetRotationPauseCounts   (void);
     void    _setupDelayForHeartbeats    (void);
     void    _rotationDelayComplete      (void);
+    QString _csvLogFilePath             (void);
+    void    _csvStartFullPulseLog       (void);
+    void    _csvStopFullPulseLog        (void);
+    void    _csvClearPrevRotationLogs   (void);
+    void    _csvStartRotationPulseLog   (int rotationCount);
+    void    _csvStopRotationPulseLog    (void);
+    void    _csvLogPulse                (QFile& csvFile, const TunnelProtocol::PulseInfo_t& pulseInfo);
+    void    _csvLogRotationStartStop    (QFile& csvFile, bool startRotation);
 
     QVariantList            _settingsPages;
     QVariantList            _instrumentPages;
@@ -149,7 +155,9 @@ private:
     int                     _lastPulseSendIndex;
     int                     _missedPulseCount;
     QmlObjectListModel      _customMapItems;
-    QFile                   _pulseLogFile;
+    QFile                   _csvFullPulseLogFile;
+    QFile                   _csvRotationPulseLogFile;
+    int                     _csvRotationCount = 1;
     TunnelProtocol::PulseInfo_t _lastPulseInfo;
 
     TagInfoList             _tagInfoList;


### PR DESCRIPTION
Screen shot shows to to log files types which are created and where:
![Screen Shot 2023-05-22 at 12 30 11](https://github.com/DonLakeFlyer/UAV-RT-TagTracker/assets/5876851/6a396a77-8ded-4213-b2b7-d442bed12625)

CSV log files can contains three types of records: Pulse, Start and Stop Rotation. In all cases the csv format is the command id from TunnelProtocol.h followed by the fields in the same order as the structures in TunnelProtocol.h.

The Pulse logs are created for each start/stop detection sequence. They include all pulses from all tags. They also include start/stop rotation entries if rotations where done.

The Rotation logs are created for each rotation that is done during a run of QGC. The number is an incrementing counter for each rotation. In the example screenshot two rotations were done. When you boot QGC previous rotation files are deleted. The rotation files contain pulses for all tags currently being detected in a single file. This turned out to be way simpler to implement. If the matlab code needs per tag processing it can just process the file multiple times for each tag it finds.
